### PR TITLE
Add i18n header with language toggle and hamburger menu

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,170 @@
+:root {
+  --bg-url: url("/assets/images/background.png");
+  --card: rgba(255,255,255,0.8);
+  --card-stroke: rgba(0,0,0,0.1);
+  --shadow: 0 4px 12px rgba(0,0,0,0.06);
+  --text: #222;
+  --muted: #666;
+  --radius: 16px;
+}
+
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Inter, Arial;
+}
+
+#bg {
+  position: fixed;
+  inset: 0;
+  background-image: var(--bg-url);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  z-index: -1;
+}
+
+/* Buttons */
+.btn {
+  display: inline-block;
+  padding: 12px 18px;
+  margin: 4px;
+  border-radius: 12px;
+  text-decoration: none;
+  border: 1px solid var(--card-stroke);
+  box-shadow: var(--shadow);
+}
+.btn.primary { background: var(--card); }
+.btn.ghost { background: transparent; }
+
+/* Pillars */
+.pillars {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  padding: 20px;
+}
+.pill {
+  flex: 1;
+  min-width: 200px;
+  padding: 20px;
+  background: var(--card);
+  border: 1px solid var(--card-stroke);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+/* ========== HEADER ========== */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 8px;
+  padding: 10px clamp(12px, 4vw, 22px);
+  backdrop-filter: blur(8px) saturate(120%);
+  background: rgba(255,255,255,0.35);
+  border-bottom: 1px solid var(--card-stroke);
+}
+
+/* Cursive title (center) */
+.brand-title {
+  justify-self: center;
+  margin: 0;
+  font-family: "Great Vibes", "Dancing Script", cursive;
+  font-size: clamp(28px, 6.5vw, 56px);
+  line-height: 1;
+  letter-spacing: 0.5px;
+  text-shadow: 0 2px 12px rgba(0,0,0,.08);
+}
+
+/* Language toggle (left) */
+.lang-toggle {
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.lang-toggle .switch {
+  appearance: none;
+  width: 54px; height: 30px;
+  border-radius: 999px;
+  border: 1px solid var(--card-stroke);
+  background: rgba(255,255,255,0.7);
+  position: relative;
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  transition: background .2s ease;
+}
+.lang-toggle .switch::after {
+  content: "EN";
+  position: absolute; inset: 2px;
+  display: grid; place-items: center;
+  font-size: 12px; font-weight: 700;
+  color: var(--text);
+}
+.lang-toggle .switch:checked::after {
+  content: "HE";
+}
+.lang-toggle label { font-size: .9rem; color: var(--muted); }
+
+/* Hamburger (right) */
+.hamburger {
+  justify-self: end;
+  width: 42px; height: 42px;
+  border-radius: 12px;
+  border: 1px solid var(--card-stroke);
+  background: rgba(255,255,255,0.65);
+  display: grid; place-items: center;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+  transition: transform .08s ease;
+}
+.hamburger:active { transform: translateY(1px); }
+.hamburger .bars, .hamburger .bars::before, .hamburger .bars::after {
+  content: "";
+  display: block;
+  width: 18px; height: 2px;
+  background: var(--text);
+  border-radius: 2px;
+  position: relative;
+}
+.hamburger .bars::before { position: absolute; top: -6px; }
+.hamburger .bars::after  { position: absolute; top: 6px; }
+
+/* Dropdown menu */
+.menu {
+  position: absolute;
+  right: clamp(12px, 4vw, 22px);
+  top: 64px;
+  width: min(260px, 86vw);
+  background: var(--card);
+  border: 1px solid var(--card-stroke);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  transform-origin: top right;
+  transform: scaleY(0.9);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform .18s ease, opacity .18s ease;
+}
+.menu.open {
+  transform: scaleY(1);
+  opacity: 1;
+  pointer-events: auto;
+}
+.menu ul { list-style: none; margin: 0; padding: 6px; }
+.menu li a {
+  display: block;
+  padding: 12px 14px;
+  border-radius: 12px;
+  color: var(--text);
+  text-decoration: none;
+}
+.menu li a:hover { background: rgba(255,255,255,0.55); }
+
+/* RTL helpers when Hebrew is active */
+:root[dir="rtl"] .site-header { grid-template-columns: 1fr auto 1fr; }
+:root[dir="rtl"] .menu { right: auto; left: clamp(12px, 4vw, 22px); transform-origin: top left; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,85 @@
+// === i18n ===
+const I18N = {
+  en: {
+    brand: "Layers of Love",
+    heroLine: "make something gentle today.",
+    "cta.ritual": "Start 2-minute ritual",
+    "cta.prompts": "Explore prompts",
+    "nav.today": "Today",
+    "nav.prompts": "Prompts",
+    "nav.create": "Create",
+    "nav.paths": "Paths",
+    "nav.gallery": "Gallery",
+    "nav.circle": "Circle",
+    "nav.profile": "Profile",
+    "pill1.title": "Daily Prompts",
+    "pill1.body": "Soft, mindful invitations for writing, sketching, or voice notes.",
+    "pill2.title": "Gentle Rituals",
+    "pill2.body": "Two-minute breath and reflect moments to return to center.",
+    "pill3.title": "Your Gallery",
+    "pill3.body": "Private by default—your quiet wins, saved with care."
+  },
+  he: {
+    brand: "שכבות של אהבה",
+    heroLine: "ליצור משהו עדין היום.",
+    "cta.ritual": "התחילי טקס של שתי דקות",
+    "cta.prompts": "גלי תזכורות ופרומפטים",
+    "nav.today": "היום",
+    "nav.prompts": "פרומפטים",
+    "nav.create": "יצירה",
+    "nav.paths": "מסלולים",
+    "nav.gallery": "גלריה",
+    "nav.circle": "חוג",
+    "nav.profile": "פרופיל",
+    "pill1.title": "פרומפטים יומיים",
+    "pill1.body": "הזמנות עדינות לכתיבה, שרטוט או הקלטת קול.",
+    "pill2.title": "טקסים עדינים",
+    "pill2.body": "נשימה ורפלקציה לשתי דקות כדי לחזור למרכז.",
+    "pill3.title": "הגלריה שלך",
+    "pill3.body": "פרטי כברירת מחדל—הנצחת הניצחונות השקטים שלך."
+  }
+};
+
+const langSwitch = document.getElementById('langSwitch');
+function applyLang(lang) {
+  const dict = I18N[lang] || I18N.en;
+  document.documentElement.setAttribute('lang', lang);
+  document.documentElement.setAttribute('dir', lang === 'he' ? 'rtl' : 'ltr');
+  // Use Heebo for Hebrew-friendly rendering
+  document.body.style.fontFamily = (lang === 'he')
+    ? 'Heebo, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial'
+    : 'ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Inter, Arial';
+
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    if (dict[key]) el.textContent = dict[key];
+  });
+
+  // Sync cursive brand title (keeps cursive font)
+  const brand = document.querySelector('.brand-title');
+  if (brand && dict['brand']) brand.textContent = dict['brand'];
+
+  localStorage.setItem('lol-lang', lang);
+  // flip toggle state
+  if (langSwitch) langSwitch.checked = (lang === 'he');
+}
+
+// Initialize language from storage or browser
+applyLang(localStorage.getItem('lol-lang') || (navigator.language?.startsWith('he') ? 'he' : 'en'));
+
+langSwitch?.addEventListener('change', (e) => {
+  applyLang(e.target.checked ? 'he' : 'en');
+});
+
+// === Hamburger menu ===
+const hamburger = document.getElementById('hamburger');
+const mainMenu = document.getElementById('mainMenu');
+function toggleMenu(open) {
+  const willOpen = typeof open === 'boolean' ? open : !mainMenu.classList.contains('open');
+  mainMenu.classList.toggle('open', willOpen);
+  hamburger.setAttribute('aria-expanded', String(willOpen));
+}
+hamburger?.addEventListener('click', () => toggleMenu());
+document.addEventListener('click', (e) => {
+  if (!mainMenu.contains(e.target) && e.target !== hamburger) toggleMenu(false);
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- Fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Heebo:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <title>Layers of Love</title>
+</head>
+<body>
+  <header class="site-header" role="banner">
+    <!-- Left: language toggle -->
+    <div class="lang-toggle">
+      <input id="langSwitch" class="switch" type="checkbox" aria-label="Toggle language" />
+    </div>
+
+    <!-- Center: cursive brand title -->
+    <h1 class="brand-title" data-i18n="brand">Layers of Love</h1>
+
+    <!-- Right: hamburger -->
+    <button id="hamburger" class="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mainMenu">
+      <span class="bars" aria-hidden="true"></span>
+    </button>
+
+    <!-- Dropdown menu -->
+    <nav id="mainMenu" class="menu" aria-label="Primary">
+      <ul>
+        <li><a href="#" data-i18n="nav.today">Today</a></li>
+        <li><a href="#" data-i18n="nav.prompts">Prompts</a></li>
+        <li><a href="#" data-i18n="nav.create">Create</a></li>
+        <li><a href="#" data-i18n="nav.paths">Paths</a></li>
+        <li><a href="#" data-i18n="nav.gallery">Gallery</a></li>
+        <li><a href="#" data-i18n="nav.circle">Circle</a></li>
+        <li><a href="#" data-i18n="nav.profile">Profile</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <div id="bg"></div>
+
+  <main>
+    <section class="hero">
+      <p class="hero-line" data-i18n="heroLine">make something gentle today.</p>
+      <div class="cta">
+        <a class="btn primary" href="#" aria-disabled="true" data-i18n="cta.ritual">Start 2-minute ritual</a>
+        <a class="btn ghost" href="#" aria-disabled="true" data-i18n="cta.prompts">Explore prompts</a>
+      </div>
+    </section>
+
+    <section class="pillars">
+      <div class="pill">
+        <h3 data-i18n="pill1.title">Daily Prompts</h3>
+        <p data-i18n="pill1.body">Soft, mindful invitations for writing, sketching, or voice notes.</p>
+      </div>
+      <div class="pill">
+        <h3 data-i18n="pill2.title">Gentle Rituals</h3>
+        <p data-i18n="pill2.body">Two-minute breath and reflect moments to return to center.</p>
+      </div>
+      <div class="pill">
+        <h3 data-i18n="pill3.title">Your Gallery</h3>
+        <p data-i18n="pill3.body">Private by default—your quiet wins, saved with care.</p>
+      </div>
+    </section>
+  </main>
+
+  <script src="/assets/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace background placeholder with watercolor image
- Add sticky header featuring cursive title, EN/HE language switch, and hamburger menu with dropdown navigation
- Implement i18n dictionary and RTL support for English/Hebrew copy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9175ad5883238bd50104efbb86cc