### PR TITLE
Add Supabase-powered admin page and public inspiration feed

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layers of Love — Admin</title>
+  <link rel="manifest" href="/manifest.webmanifest">
+  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <style>
+    /* lightweight admin card styling on top of existing CSS */
+    .admin-wrap {
+      width: min(820px, 92%);
+      margin: 6vh auto;
+      padding: clamp(16px, 2.8vw, 28px);
+      background: var(--card);
+      border: 1px solid var(--card-stroke);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(10px) saturate(125%);
+    }
+    .row { display: grid; gap: 8px; margin: 12px 0; }
+    .row label { font-weight: 600; }
+    textarea, input[type="text"], input[type="url"], button {
+      border: 1px solid var(--card-stroke);
+      border-radius: 12px;
+      padding: 10px 12px;
+    }
+    textarea { min-height: 110px; resize: vertical; }
+    .danger { color: #7a1f2a; font-weight: 700; }
+    .ok { color: #1f5e40; font-weight: 700; }
+    .muted { color: var(--muted); font-size: .9rem; }
+    .stack { display: grid; gap: 10px; }
+  </style>
+</head>
+<body>
+  <div id="bg"></div>
+
+  <main class="admin-wrap">
+    <h1 class="brand-title" style="justify-self:start">Layers of Love — Admin</h1>
+
+    <section class="stack">
+      <div class="row">
+        <button id="loginPasskey" class="btn">Sign in / Register (Passkey or Magic Link)</button>
+        <button id="logout" class="btn ghost">Sign out</button>
+        <div id="authState" class="muted">Not signed in</div>
+      </div>
+
+      <hr/>
+
+      <h2>Inspiration of the Day</h2>
+      <div class="row">
+        <label for="inspText">Text</label>
+        <textarea id="inspText" placeholder="Write today’s inspiration..."></textarea>
+        <button id="postInspiration" class="btn primary">Post for Today</button>
+        <div id="inspMsg" class="muted"></div>
+      </div>
+
+      <hr/>
+
+      <h2>Videos (URLs)</h2>
+      <div class="row">
+        <label for="vidTitle">Title</label>
+        <input id="vidTitle" type="text" placeholder="e.g., Watercolor grounding ritual" />
+        <label for="vidUrl">Video URL</label>
+        <input id="vidUrl" type="url" placeholder="https://www.youtube.com/watch?v=..." />
+        <button id="addVideo" class="btn">Add Video</button>
+        <div id="vidMsg" class="muted"></div>
+      </div>
+    </section>
+  </main>
+
+  <script type="module" src="/assets/js/admin.js"></script>
+</body>
+</html>

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,104 @@
+import { sb, fmtErr } from "./supa.js";
+import { HER_UUID } from "./config.js";
+
+/** UI refs */
+const loginBtn = document.getElementById("loginPasskey");
+const logoutBtn = document.getElementById("logout");
+const authState = document.getElementById("authState");
+
+const inspText = document.getElementById("inspText");
+const postInspirationBtn = document.getElementById("postInspiration");
+const inspMsg = document.getElementById("inspMsg");
+
+const vidTitle = document.getElementById("vidTitle");
+const vidUrl = document.getElementById("vidUrl");
+const addVideoBtn = document.getElementById("addVideo");
+const vidMsg = document.getElementById("vidMsg");
+
+function ok(msg){ inspMsg.textContent = msg; inspMsg.className = "ok"; }
+function err(el,msg){ el.textContent = msg; el.className = "danger"; }
+
+/** Auth */
+async function refreshAuthUI() {
+  const client = await sb();
+  const { data: { user } } = await client.auth.getUser();
+  if (user) {
+    authState.textContent = `Signed in as ${user.email || user.id}`;
+    // Only HER_UUID can see posting controls
+    const isHer = user.id === HER_UUID;
+    postInspirationBtn.disabled = !isHer;
+    addVideoBtn.disabled = !isHer;
+    inspText.disabled = !isHer;
+    vidTitle.disabled = !isHer;
+    vidUrl.disabled = !isHer;
+    if (!isHer) {
+      authState.textContent += " (view-only; not authorized to post)";
+    }
+  } else {
+    authState.textContent = "Not signed in";
+    [postInspirationBtn, addVideoBtn, inspText, vidTitle, vidUrl].forEach(el => el.disabled = true);
+  }
+}
+
+loginBtn?.addEventListener("click", async () => {
+  const client = await sb();
+  try {
+    // Try passkey first; if unavailable, fallback to magic-link prompt
+    const { data: passkey } = await client.auth.signInWithSSO({ domain: "passkeys" }).catch(() => ({ data: null }));
+    if (!passkey) {
+      const email = prompt("Enter your email to receive a sign-in link:");
+      if (!email) return;
+      const { error } = await client.auth.signInWithOtp({ email, options: { emailRedirectTo: location.href } });
+      if (error) throw error;
+      alert("Check your email for a magic link. After opening it, return to this page.");
+    }
+  } catch (e) {
+    alert("Sign-in failed: " + fmtErr(e));
+  } finally {
+    setTimeout(refreshAuthUI, 800);
+  }
+});
+
+logoutBtn?.addEventListener("click", async () => {
+  const client = await sb();
+  await client.auth.signOut();
+  await refreshAuthUI();
+});
+
+/** Post Inspiration of the Day */
+postInspirationBtn?.addEventListener("click", async () => {
+  const client = await sb();
+  const text = (inspText.value || "").trim();
+  if (!text) return err(inspMsg, "Please write something.");
+  try {
+    const today = new Date().toISOString().slice(0,10);
+    const { error } = await client
+      .from("inspirations")
+      .upsert({ date: today, text, author_id: HER_UUID }, { onConflict: "date" });
+    if (error) throw error;
+    ok("Saved today’s inspiration.");
+  } catch (e) {
+    err(inspMsg, fmtErr(e));
+  }
+});
+
+/** Add Video (URL) */
+addVideoBtn?.addEventListener("click", async () => {
+  const client = await sb();
+  const title = (vidTitle.value || "").trim();
+  const url = (vidUrl.value || "").trim();
+  if (!title || !url) return err(vidMsg, "Please fill both Title and URL.");
+  try {
+    const { error } = await client
+      .from("resources")
+      .insert({ title, url, type: "video", author_id: HER_UUID });
+    if (error) throw error;
+    vidMsg.className = "ok";
+    vidMsg.textContent = "Video saved.";
+    vidTitle.value = ""; vidUrl.value = "";
+  } catch (e) {
+    err(vidMsg, fmtErr(e));
+  }
+});
+
+window.addEventListener("load", refreshAuthUI);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -83,3 +83,25 @@ hamburger?.addEventListener('click', () => toggleMenu());
 document.addEventListener('click', (e) => {
   if (!mainMenu.contains(e.target) && e.target !== hamburger) toggleMenu(false);
 });
+
+import { sb as sbPublic } from "./supa.js";
+
+async function loadInspiration() {
+  try {
+    const client = await sbPublic();
+    const { data, error } = await client
+      .from("inspirations")
+      .select("text,date")
+      .order("date", { ascending: false })
+      .limit(1);
+    if (error) throw error;
+    const el = document.querySelector("[data-i18n='heroLine']");
+    if (el && data && data[0]?.text) {
+      el.textContent = data[0].text;
+    }
+  } catch (e) {
+    // keep default hero line silently
+  }
+}
+loadInspiration();
+

--- a/assets/js/config.sample.js
+++ b/assets/js/config.sample.js
@@ -1,0 +1,83 @@
+/**
+ * Copy this file to: /assets/js/config.js
+ * Then fill in your values from Supabase Project Settings → API.
+ * It's OK to ship the anon key to the client because RLS protects writes.
+ */
+export const SUPABASE_URL = "https://YOUR-PROJECT.supabase.co";
+export const SUPABASE_ANON_KEY = "YOUR-ANON-PUBLIC-KEY";
+/**
+ * After you create your sister's account, replace HER_UUID below.
+ * How to get it: Supabase Dashboard → Authentication → Users → copy the UUID.
+ */
+export const HER_UUID = "REPLACE-WITH-HER-USER-UUID";
+
+/*
+-----------------------------------------------------------------------------
+SQL setup (run in Supabase SQL Editor):
+
+-- Table: inspirations (one per day)
+create table if not exists public.inspirations (
+  id uuid primary key default gen_random_uuid(),
+  date date not null unique,
+  text text not null,
+  author_id uuid not null,
+  created_at timestamp with time zone default now()
+);
+
+-- Table: resources (video URLs)
+create table if not exists public.resources (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  url text not null,
+  type text not null default 'video',
+  author_id uuid not null,
+  created_at timestamp with time zone default now()
+);
+
+-- Enable Row Level Security
+alter table public.inspirations enable row level security;
+alter table public.resources enable row level security;
+
+-- Policies: Public can read; only HER_UUID can write.
+-- Replace 00000000-0000-0000-0000-000000000000 with your sister's UUID.
+-- You can add the UUID after her first sign-in, then rerun/update the policy.
+
+-- READ (public)
+create policy "inspirations_select_public"
+on public.inspirations for select
+using ( true );
+
+create policy "resources_select_public"
+on public.resources for select
+using ( true );
+
+-- WRITE (only her)
+create policy "inspirations_write_her_only"
+on public.inspirations for insert with check ( auth.uid() = author_id and author_id = '00000000-0000-0000-0000-000000000000'::uuid );
+
+create policy "inspirations_update_her_only"
+on public.inspirations for update using ( auth.uid() = author_id and author_id = '00000000-0000-0000-0000-000000000000'::uuid );
+
+create policy "resources_write_her_only"
+on public.resources for insert with check ( auth.uid() = author_id and author_id = '00000000-0000-0000-0000-000000000000'::uuid );
+
+create policy "resources_update_her_only"
+on public.resources for update using ( auth.uid() = author_id and author_id = '00000000-0000-0000-0000-000000000000'::uuid );
+
+-- Optional: allow her to delete her own posts
+create policy "inspirations_delete_her_only"
+on public.inspirations for delete using ( auth.uid() = author_id and author_id = '00000000-0000-0000-0000-000000000000'::uuid );
+
+create policy "resources_delete_her_only"
+on public.resources for delete using ( auth.uid() = author_id and author_id = '00000000-0000-0000-0000-000000000000'::uuid );
+
+-----------------------------------------------------------------------------
+Auth setup:
+- In Supabase Dashboard → Authentication → Providers:
+  - Enable Email (magic link).
+  - (Optional) Enable Passkeys.
+- Have your sister sign in once via magic link to create her user.
+- Copy her UUID → set HER_UUID above.
+- Re-run/update the RLS policies to include her UUID if you didn’t set it earlier.
+-----------------------------------------------------------------------------
+*/

--- a/assets/js/supa.js
+++ b/assets/js/supa.js
@@ -1,0 +1,21 @@
+// Minimal Supabase client (ESM) without bundlers.
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from "./config.js";
+
+export async function sb() {
+  // Load the edge-friendly browser client from CDN
+  if (!window.supabase) {
+    await import("https://esm.sh/@supabase/supabase-js@2?bundle-deps");
+  }
+  return window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: true,
+      flowType: "pkce",
+      autoRefreshToken: true,
+      detectSessionInUrl: true
+    }
+  });
+}
+
+export function fmtErr(e) {
+  return e?.message || e?.error_description || String(e);
+}

--- a/index.html
+++ b/index.html
@@ -64,6 +64,9 @@
     </section>
   </main>
 
-  <script src="/assets/js/app.js"></script>
+  <script type="module" src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/supa.js"></script>
+  <script type="module" src="/assets/js/app.js"></script>
+  <!-- IMPORTANT: You must create /assets/js/config.js by copying config.sample.js and filling values. -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add sample Supabase config with table & policy SQL notes
- Build lightweight admin page with passkey/magic-link auth and posting tools
- Fetch latest inspiration on homepage via Supabase

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba938694288323b4bbf3ba9fcee2a9