### PR TITLE
Add podcasts, social, inspiration, and about pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layers of Love — About</title>
+  <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Heebo:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./assets/css/styles.css" />
+</head>
+<body>
+  <div id="bg"></div>
+
+  <header class="site-header" role="banner">
+    <div class="lang-toggle"><input id="langSwitch" class="switch" type="checkbox" aria-label="Toggle language" /></div>
+    <h1 class="brand-title" data-i18n="brand">Layers of Love</h1>
+    <button id="hamburger" class="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mainMenu"><span class="bars"></span></button>
+    <nav id="mainMenu" class="menu" aria-label="Primary">
+      <ul>
+        <li><a href="./index.html" data-i18n="nav.today">Today</a></li>
+        <li><a href="./podcasts.html" data-i18n="nav.podcasts">Podcasts</a></li>
+        <li><a href="./social.html" data-i18n="nav.social">Social Media</a></li>
+        <li><a href="./inspiration.html" data-i18n="nav.daily">Daily Inspiration</a></li>
+        <li><a href="./about.html" data-i18n="nav.about">About</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="page-wrap">
+    <section class="page-hero">
+      <h2 class="page-title" data-i18n="about.title">Who is Avital?</h2>
+    </section>
+
+    <section class="card-list">
+      <article class="card">
+        <p data-i18n="about.body">
+          A woman who embodies the true meaning of femininity and motherhood.
+          A woman who taps into what it means to be a woman in today's modern day and age,
+          and still connects to the women who came before her — to body and soul —
+          in ways that heal and rejuvenate.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <script type="module" src="./assets/js/app.js"></script>
+</body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -168,3 +168,27 @@ body {
 /* RTL helpers when Hebrew is active */
 :root[dir="rtl"] .site-header { grid-template-columns: 1fr auto 1fr; }
 :root[dir="rtl"] .menu { right: auto; left: clamp(12px, 4vw, 22px); transform-origin: top left; }
+
+/* ===== Page layout ===== */
+.page-wrap { width: min(1000px, 94%); margin: 4vh auto 8vh; }
+.page-hero { text-align: center; margin-bottom: 16px; }
+.page-title {
+  margin: 0 0 6px 0;
+  font-weight: 800;
+  letter-spacing: .2px;
+  font-size: clamp(22px, 4.5vw, 34px);
+}
+.page-sub { color: var(--muted); margin: 0 auto; max-width: 60ch; }
+
+/* Cards */
+.card-list { display: grid; gap: 14px; }
+@media (min-width: 720px) { .card-list { grid-template-columns: repeat(3, 1fr); } }
+.card {
+  background: var(--card);
+  border: 1px solid var(--card-stroke);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  box-shadow: var(--shadow);
+}
+.card h3 { margin: 4px 0 6px 0; font-size: 1.05rem; }
+.card.muted { opacity: .85; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -17,7 +17,19 @@ const I18N = {
     "pill2.title": "Gentle Rituals",
     "pill2.body": "Two-minute breath and reflect moments to return to center.",
     "pill3.title": "Your Gallery",
-    "pill3.body": "Private by default—your quiet wins, saved with care."
+    "pill3.body": "Private by default—your quiet wins, saved with care.",
+    "nav.podcasts": "Podcasts",
+    "nav.social": "Social Media",
+    "nav.daily": "Daily Inspiration",
+    "nav.about": "About",
+    "podcasts.title": "Podcasts",
+    "podcasts.sub": "Listen to gentle, honest conversations about creativity, motherhood, and healing.",
+    "social.title": "Social Media",
+    "social.sub": "Find Avital’s art and updates here.",
+    "daily.title": "Daily Inspiration",
+    "daily.sub": "A gentle note from Avital, updated over time.",
+    "about.title": "Who is Avital?",
+    "about.body": "A woman who embodies the true meaning of femininity and motherhood. A woman who taps into what it means to be a woman in today's modern day and age, and still connects to the women who came before her — to body and soul — in ways that heal and rejuvenate."
   },
   he: {
     brand: "שכבות של אהבה",
@@ -36,7 +48,19 @@ const I18N = {
     "pill2.title": "טקסים עדינים",
     "pill2.body": "נשימה ורפלקציה לשתי דקות כדי לחזור למרכז.",
     "pill3.title": "הגלריה שלך",
-    "pill3.body": "פרטי כברירת מחדל—הנצחת הניצחונות השקטים שלך."
+    "pill3.body": "פרטי כברירת מחדל—הנצחת הניצחונות השקטים שלך.",
+    "nav.podcasts": "פודקאסטים",
+    "nav.social": "רשתות חברתיות",
+    "nav.daily": "השראה יומית",
+    "nav.about": "אודות",
+    "podcasts.title": "פודקאסטים",
+    "podcasts.sub": "שיחות עדינות וכנות על יצירה, אמהות וריפוי.",
+    "social.title": "רשתות חברתיות",
+    "social.sub": "כאן תמצאו את האמנות והעדכונים של אביטל.",
+    "daily.title": "השראה יומית",
+    "daily.sub": "מילים עדינות מאביטל, מתעדכנות עם הזמן.",
+    "about.title": "מי היא אביטל?",
+    "about.body": "אישה שמגלמת את המשמעות האמיתית של נשיות ואימהוּת. אישה שמתחברת למהות האישה בעידן המודרני, ועדיין קשובה לנשים שלפניה — לגוף ולנפש — בדרכים שמרפאות ומחדשות."
   }
 };
 
@@ -84,10 +108,9 @@ document.addEventListener('click', (e) => {
   if (!mainMenu.contains(e.target) && e.target !== hamburger) toggleMenu(false);
 });
 
-import { sb as sbPublic } from "./supa.js";
-
 async function loadInspiration() {
   try {
+    const { sb: sbPublic } = await import("./supa.js");
     const client = await sbPublic();
     const { data, error } = await client
       .from("inspirations")
@@ -104,4 +127,35 @@ async function loadInspiration() {
   }
 }
 loadInspiration();
+
+(async () => {
+  // Only run on /inspiration.html and only if supa.js is present
+  const onInspirationPage = location.pathname.endsWith("/inspiration.html") || location.pathname.endsWith("inspiration.html");
+  if (!onInspirationPage) return;
+
+  try {
+    const { sb: sbPublic } = await import("./supa.js").catch(() => ({}));
+    if (!sbPublic) return; // no supabase: skip
+    const client = await sbPublic();
+    const { data, error } = await client
+      .from("inspirations")
+      .select("text,date")
+      .order("date", { ascending: false })
+      .limit(30);
+    if (error || !data) return;
+
+    const list = document.getElementById("inspList");
+    const fb = document.getElementById("inspFallback");
+    if (list && fb) fb.remove();
+
+    data.forEach(row => {
+      const card = document.createElement("article");
+      card.className = "card";
+      card.innerHTML = `<h3>${row.date}</h3><p>${row.text}</p>`;
+      list?.appendChild(card);
+    });
+  } catch (_) {
+    /* silent */
+  }
+})();
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Heebo:wght@400;600;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="stylesheet" href="./assets/css/styles.css" />
   <title>Layers of Love</title>
 </head>
 <body>
@@ -26,13 +26,11 @@
     <!-- Dropdown menu -->
     <nav id="mainMenu" class="menu" aria-label="Primary">
       <ul>
-        <li><a href="#" data-i18n="nav.today">Today</a></li>
-        <li><a href="#" data-i18n="nav.prompts">Prompts</a></li>
-        <li><a href="#" data-i18n="nav.create">Create</a></li>
-        <li><a href="#" data-i18n="nav.paths">Paths</a></li>
-        <li><a href="#" data-i18n="nav.gallery">Gallery</a></li>
-        <li><a href="#" data-i18n="nav.circle">Circle</a></li>
-        <li><a href="#" data-i18n="nav.profile">Profile</a></li>
+        <li><a href="./index.html" data-i18n="nav.today">Today</a></li>
+        <li><a href="./podcasts.html" data-i18n="nav.podcasts">Podcasts</a></li>
+        <li><a href="./social.html" data-i18n="nav.social">Social Media</a></li>
+        <li><a href="./inspiration.html" data-i18n="nav.daily">Daily Inspiration</a></li>
+        <li><a href="./about.html" data-i18n="nav.about">About</a></li>
       </ul>
     </nav>
   </header>
@@ -64,9 +62,6 @@
     </section>
   </main>
 
-  <script type="module" src="/assets/js/config.js"></script>
-  <script type="module" src="/assets/js/supa.js"></script>
-  <script type="module" src="/assets/js/app.js"></script>
-  <!-- IMPORTANT: You must create /assets/js/config.js by copying config.sample.js and filling values. -->
+  <script type="module" src="./assets/js/app.js"></script>
 </body>
 </html>

--- a/inspiration.html
+++ b/inspiration.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layers of Love — Daily Inspiration</title>
+  <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Heebo:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./assets/css/styles.css" />
+</head>
+<body>
+  <div id="bg"></div>
+
+  <header class="site-header" role="banner">
+    <div class="lang-toggle"><input id="langSwitch" class="switch" type="checkbox" aria-label="Toggle language" /></div>
+    <h1 class="brand-title" data-i18n="brand">Layers of Love</h1>
+    <button id="hamburger" class="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mainMenu"><span class="bars"></span></button>
+    <nav id="mainMenu" class="menu" aria-label="Primary">
+      <ul>
+        <li><a href="./index.html" data-i18n="nav.today">Today</a></li>
+        <li><a href="./podcasts.html" data-i18n="nav.podcasts">Podcasts</a></li>
+        <li><a href="./social.html" data-i18n="nav.social">Social Media</a></li>
+        <li><a href="./inspiration.html" data-i18n="nav.daily">Daily Inspiration</a></li>
+        <li><a href="./about.html" data-i18n="nav.about">About</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="page-wrap">
+    <section class="page-hero">
+      <h2 class="page-title" data-i18n="daily.title">Daily Inspiration</h2>
+      <p class="page-sub" data-i18n="daily.sub">A gentle note from Avital, updated over time.</p>
+    </section>
+
+    <section class="card-list" id="inspList">
+      <!-- JS will render cards here -->
+      <article class="card muted" id="inspFallback">
+        <h3>Coming soon</h3>
+        <p>This page will show a list of inspirations as Avital posts them.</p>
+      </article>
+    </section>
+  </main>
+
+  <!-- If Supabase is not configured, app.js will silently skip fetch -->
+  <script type="module" src="./assets/js/app.js"></script>
+</body>
+</html>

--- a/podcasts.html
+++ b/podcasts.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layers of Love — Podcasts</title>
+  <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Heebo:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./assets/css/styles.css" />
+</head>
+<body>
+  <div id="bg"></div>
+
+  <!-- Shared header -->
+  <header class="site-header" role="banner">
+    <div class="lang-toggle"><input id="langSwitch" class="switch" type="checkbox" aria-label="Toggle language" /></div>
+    <h1 class="brand-title" data-i18n="brand">Layers of Love</h1>
+    <button id="hamburger" class="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mainMenu"><span class="bars"></span></button>
+    <nav id="mainMenu" class="menu" aria-label="Primary">
+      <ul>
+        <li><a href="./index.html" data-i18n="nav.today">Today</a></li>
+        <li><a href="./podcasts.html" data-i18n="nav.podcasts">Podcasts</a></li>
+        <li><a href="./social.html" data-i18n="nav.social">Social Media</a></li>
+        <li><a href="./inspiration.html" data-i18n="nav.daily">Daily Inspiration</a></li>
+        <li><a href="./about.html" data-i18n="nav.about">About</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="page-wrap">
+    <section class="page-hero">
+      <h2 class="page-title" data-i18n="podcasts.title">Podcasts</h2>
+      <p class="page-sub" data-i18n="podcasts.sub">Listen to gentle, honest conversations about creativity, motherhood, and healing.</p>
+    </section>
+
+    <section class="card-list">
+      <!-- Replace these links with real podcast URLs as they come -->
+      <article class="card">
+        <h3>Returning to Center</h3>
+        <p>5-minute reset ritual you can take on a walk.</p>
+        <a class="btn" href="#" target="_blank" rel="noopener">Play episode</a>
+      </article>
+
+      <article class="card">
+        <h3>Soft Strength</h3>
+        <p>Why gentleness is not weakness.</p>
+        <a class="btn" href="#" target="_blank" rel="noopener">Play episode</a>
+      </article>
+
+      <article class="card">
+        <h3>Motherhood & Art</h3>
+        <p>Creating in small pockets of time.</p>
+        <a class="btn" href="#" target="_blank" rel="noopener">Play episode</a>
+      </article>
+    </section>
+  </main>
+
+  <script type="module" src="./assets/js/app.js"></script>
+</body>
+</html>

--- a/social.html
+++ b/social.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layers of Love — Social Media</title>
+  <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Heebo:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./assets/css/styles.css" />
+</head>
+<body>
+  <div id="bg"></div>
+
+  <header class="site-header" role="banner">
+    <div class="lang-toggle"><input id="langSwitch" class="switch" type="checkbox" aria-label="Toggle language" /></div>
+    <h1 class="brand-title" data-i18n="brand">Layers of Love</h1>
+    <button id="hamburger" class="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mainMenu"><span class="bars"></span></button>
+    <nav id="mainMenu" class="menu" aria-label="Primary">
+      <ul>
+        <li><a href="./index.html" data-i18n="nav.today">Today</a></li>
+        <li><a href="./podcasts.html" data-i18n="nav.podcasts">Podcasts</a></li>
+        <li><a href="./social.html" data-i18n="nav.social">Social Media</a></li>
+        <li><a href="./inspiration.html" data-i18n="nav.daily">Daily Inspiration</a></li>
+        <li><a href="./about.html" data-i18n="nav.about">About</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="page-wrap">
+    <section class="page-hero">
+      <h2 class="page-title" data-i18n="social.title">Social Media</h2>
+      <p class="page-sub" data-i18n="social.sub">Find Avital’s art and updates here.</p>
+    </section>
+
+    <section class="card-list">
+      <article class="card">
+        <h3>Instagram</h3>
+        <p>Works in progress, finished pieces, and behind the scenes.</p>
+        <a class="btn" href="#" target="_blank" rel="noopener">Open Instagram</a>
+      </article>
+
+      <article class="card">
+        <h3>TikTok</h3>
+        <p>Short process videos and mini lessons.</p>
+        <a class="btn" href="#" target="_blank" rel="noopener">Open TikTok</a>
+      </article>
+
+      <article class="card">
+        <h3>YouTube</h3>
+        <p>Longer tutorials and gentle talks.</p>
+        <a class="btn" href="#" target="_blank" rel="noopener">Open YouTube</a>
+      </article>
+    </section>
+  </main>
+
+  <script type="module" src="./assets/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add public pages for Podcasts, Social Media, Daily Inspiration, and About with shared header and cards
- style page layout and cards
- extend i18n keys and load Supabase inspirations when configured

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9782cac083239ae5e6f90df939c8