### PR TITLE
Add watercolor background and glass UI polish

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Layers of Love — Admin</title>
-  <link rel="manifest" href="/manifest.webmanifest">
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="manifest" href="./manifest.webmanifest">
+  <link rel="stylesheet" href="./assets/css/styles.css" />
   <style>
     /* lightweight admin card styling on top of existing CSS */
     .admin-wrap {
@@ -69,6 +69,7 @@
     </section>
   </main>
 
-  <script type="module" src="/assets/js/admin.js"></script>
+  <script type="module" src="./assets/js/app.js"></script>
+  <script type="module" src="./assets/js/admin.js"></script>
 </body>
 </html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -16,10 +16,13 @@ body {
 #bg {
   position: fixed;
   inset: 0;
-  background-image: var(--bg-url);
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
+  background-image:
+    radial-gradient(1200px 600px at 12% 0%, rgba(255,255,255,0.55), rgba(255,255,255,0.18) 42%, rgba(255,255,255,0.00) 65%),
+    var(--bg-url);
+  background-size: cover, cover;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+  filter: saturate(108%);
   z-index: -1;
 }
 
@@ -166,9 +169,49 @@ body {
 .card h3 { margin: 4px 0 6px 0; font-size: 1.05rem; }
 .card.muted { opacity: .85; }
 
-/* Ensure background covers full viewport on mobile */
+/* Global rhythm */
+main { padding: clamp(12px, 2.5vw, 24px); }
+
+/* Make the hero breathe */
+.hero { margin: 16px auto 8px; max-width: 1000px; }
+.hero-line { margin: 0 0 12px; font-size: clamp(18px, 2.6vw, 24px); }
+
+/* Buttons / Glass look */
+.btn {
+  background: rgba(255,255,255,0.72);
+  backdrop-filter: blur(6px) saturate(115%);
+  transition: transform .08s ease, box-shadow .18s ease, background .18s ease;
+}
+.btn:hover { transform: translateY(-1px); box-shadow: 0 8px 24px rgba(0,0,0,0.12); }
+.btn:active { transform: translateY(0); }
+.btn.primary {
+  background: linear-gradient(180deg, rgba(255,255,255,0.86) 0%, rgba(255,255,255,0.72) 100%);
+}
+
+/* Cards */
+.pill, .card {
+  background: rgba(255,255,255,0.68);
+  backdrop-filter: blur(10px) saturate(120%);
+  transition: transform .18s ease, box-shadow .22s ease, background .22s ease;
+}
+.pill:hover, .card:hover { transform: translateY(-2px); box-shadow: 0 14px 34px rgba(0,0,0,0.14); }
+
+/* Header transparency */
+.site-header {
+  background: rgba(255,255,255,0.38);
+  backdrop-filter: blur(8px) saturate(120%);
+}
+
+/* Menu sheet style */
+.menu { background: rgba(255,255,255,0.75); }
+
+/* Fine-tune spacing for 3-up pillars on wide screens */
+@media (min-width: 960px) {
+  .pillars { padding-top: 8px; }
+}
+
+/* Mobile background performance */
 #bg { background-attachment: fixed; }
 @supports (-webkit-touch-callout: none) {
-  /* iOS fallback: avoid fixed to reduce repaint costs */
   #bg { background-attachment: scroll; }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -158,3 +158,18 @@ loadInspiration();
     /* silent */
   }
 })();
+
+// Gentle entrance animation for cards/pills
+window.addEventListener('load', () => {
+  document.querySelectorAll('.pill, .card').forEach((el, i) => {
+    el.style.opacity = '0';
+    el.style.transform = 'translateY(6px)';
+    el.style.transition = 'opacity .36s ease, transform .36s ease';
+    requestAnimationFrame(() => {
+      setTimeout(() => {
+        el.style.opacity = '1';
+        el.style.transform = 'translateY(0)';
+      }, 60 + i * 70);
+    });
+  });
+});

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "Layers of Love",
+  "short_name": "Layers",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff"
+}


### PR DESCRIPTION
## Summary
- Replace background with watercolor overlay and add glassy button/card styling plus spacing tweaks.
- Ensure admin page uses relative asset paths and loads both app and admin scripts.
- Animate cards/pills on load and include web manifest with project-relative scope.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9e4df6708323b4bf6f1a8479c81a