### PR TITLE
feat: add design playground for site prototypes

### DIFF
--- a/assets/css/playground.css
+++ b/assets/css/playground.css
@@ -1,0 +1,62 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.top-bar {
+  padding: 8px 12px;
+  background: #333;
+  color: #fff;
+}
+.playground {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+#palette {
+  width: 260px;
+  overflow-y: auto;
+  border-right: 1px solid #ccc;
+  padding: 8px;
+  background: #f5f5f5;
+}
+#palette .category { margin-bottom: 16px; }
+#palette .category h3 {
+  margin: 8px 0;
+  font-size: 14px;
+}
+.palette-item {
+  border: 1px solid #bbb;
+  padding: 4px 6px;
+  margin: 2px 0;
+  background: #fff;
+  cursor: grab;
+  user-select: none;
+  font-size: 13px;
+}
+#canvas {
+  flex: 1;
+  position: relative;
+  background: #fff;
+}
+.element {
+  position: absolute;
+  padding: 6px 10px;
+  border: 1px dashed #666;
+  background: rgba(240,240,240,0.9);
+  cursor: move;
+  min-width: 40px;
+  min-height: 20px;
+  display: inline-block;
+}
+.actions {
+  padding: 8px;
+  border-top: 1px solid #ccc;
+  background: #fafafa;
+}
+#output {
+  width: 100%;
+  height: 120px;
+}

--- a/assets/js/playground.js
+++ b/assets/js/playground.js
@@ -1,0 +1,146 @@
+const ELEMENT_CATEGORIES = {
+  "Core text & typography": [
+    "paragraph","h1","h2","h3","h4","h5","h6","small","span","em","strong","code","kbd","samp","pre","blockquote","q","abbr","time","mark","sup","sub","hr"
+  ],
+  "Links & basic interactivity": [
+    "hyperlink","anchor target","download link","telephone link","mailto link"
+  ],
+  "Media": [
+    "image","responsive picture","audio","video","embedded content","inline svg","canvas","figure","figcaption"
+  ],
+  "Semantics & document structure": [
+    "div","section","article","header","footer","nav","main","aside","address","details","summary","dialog","template","slot","custom element"
+  ],
+  "Forms — inputs & controls": [
+    "form","label","fieldset","legend","input text","input password","input email","input search","input tel","input url","input number","input color","input date","input time","input datetime-local","input month","input week","input range","input checkbox","input radio","input file","input hidden","input image","textarea","select","option","optgroup","datalist","output","progress","meter","button","validation message","helper text","counter"
+  ],
+  "Buttons & clickable components": [
+    "primary button","secondary button","tertiary button","icon button","segmented buttons","toggle button","split button","floating action button","button group","toolbar"
+  ],
+  "Pickers & selection": [
+    "dropdown","listbox","combobox","multiselect","date picker","time picker","datetime picker","color picker","file picker","rating stars","chip selector"
+  ],
+  "Toggles & disclosure": [
+    "switch","checkbox list","radio group","accordion","details expander"
+  ],
+  "Navigation": [
+    "site header","navbar","sidebar","breadcrumb","tabs","pagination","stepper","anchor link list","skip link"
+  ],
+  "Menus": [
+    "menu","menubar","context menu","kebab menu","dropdown menu","command palette"
+  ],
+  "Overlays": [
+    "modal dialog","side sheet","popover","tooltip","hovercard","lightbox"
+  ],
+  "Feedback & status": [
+    "toast","banner","callout","inline validation error","loading spinner","skeleton loader","progress bar","empty state","status badge"
+  ],
+  "Badges, tags, metadata": [
+    "badge","chip","label","status dot","avatar","presence indicator"
+  ],
+  "Search": [
+    "search field","search autocomplete","search filters","filter chips","saved searches"
+  ],
+  "Data display": [
+    "table","data grid","definition list","list","caption","key-value list","statistic tile","KPI card","timeline","tree view","tree grid","collapsible list","carousel","card","media object","gallery","badge list","map pin list"
+  ],
+  "Layout & containers": [
+    "container","grid","flex row","flex column","responsive columns","stack","cluster","wrap","divider","spacer","sheet","panel","sticky header","sticky footer","scroll area","splitter"
+  ],
+  "Charts & visualization": [
+    "line chart","area chart","bar chart","pie chart","scatter plot","histogram","heatmap","radar chart","gauge","sparkline","map","tree map","network graph","timeline chart"
+  ],
+  "Commerce & transactional": [
+    "price display","quantity stepper","add-to-cart","cart drawer","checkout form","payment selector","order summary","receipt"
+  ],
+  "Social & communication": [
+    "share buttons","reactions","comments thread","mention autocomplete","message bubble","typing indicator","notification bell"
+  ],
+  "File & upload": [
+    "file input","drag-and-drop zone","upload queue","file preview","image cropper"
+  ],
+  "Maps & geospatial": [
+    "map canvas","marker","geocoder search","layer toggle","scale/legend","minimap"
+  ],
+  "Editors & content creation": [
+    "rich text editor","markdown editor","code editor","diff viewer","annotation","emoji picker"
+  ],
+  "Authentication & identity": [
+    "sign in form","sign up form","federated login buttons","2FA input","password strength meter","user menu","profile card"
+  ],
+  "Internationalization & locale": [
+    "language switcher","currency selector","timezone picker"
+  ],
+  "Accessibility landmarks & aids": [
+    "banner landmark","navigation landmark","main landmark","complementary landmark","contentinfo landmark","aria-live region","focus outline","skip links","high-contrast toggle","font-size control"
+  ],
+  "HTML/ARIA widget roles": [
+    "role alert","role alertdialog","role button","role checkbox","role combobox","role dialog","role grid","role gridcell","role link","role listbox","role option","role menu","role menubar","role menuitem","role progressbar","role radio","role radiogroup","role scrollbar","role slider","role spinbutton","role switch","role tab","role tablist","role tabpanel","role textbox","role timer","role tooltip","role tree","role treeitem","role treegrid"
+  ],
+  "Misc utility patterns": [
+    "breadcrumbs skeleton","back-to-top button","cookie consent banner","print view","offline indicator","command shortcut hints"
+  ]
+};
+
+const palette = document.getElementById('palette');
+const canvas = document.getElementById('canvas');
+
+for (const [category, items] of Object.entries(ELEMENT_CATEGORIES)) {
+  const group = document.createElement('div');
+  group.className = 'category';
+  const heading = document.createElement('h3');
+  heading.textContent = category;
+  group.appendChild(heading);
+  items.forEach(name => {
+    const item = document.createElement('div');
+    item.className = 'palette-item';
+    item.draggable = true;
+    item.textContent = name;
+    item.dataset.name = name;
+    group.appendChild(item);
+  });
+  palette.appendChild(group);
+}
+
+palette.addEventListener('dragstart', e => {
+  if (e.target.classList.contains('palette-item')) {
+    e.dataTransfer.setData('text/plain', e.target.dataset.name);
+  }
+});
+
+canvas.addEventListener('dragover', e => e.preventDefault());
+
+canvas.addEventListener('drop', e => {
+  e.preventDefault();
+  const name = e.dataTransfer.getData('text/plain');
+  if (!name) return;
+  const el = document.createElement('div');
+  el.className = 'element';
+  el.textContent = name;
+  el.style.left = e.offsetX + 'px';
+  el.style.top = e.offsetY + 'px';
+  canvas.appendChild(el);
+  interact(el).draggable({listeners:{move: dragMove}});
+});
+
+function dragMove (event) {
+  const target = event.target;
+  const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
+  const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+  target.style.transform = `translate(${x}px, ${y}px)`;
+  target.setAttribute('data-x', x);
+  target.setAttribute('data-y', y);
+}
+
+document.getElementById('export-html').addEventListener('click', () => {
+  document.getElementById('output').value = canvas.innerHTML;
+});
+
+document.getElementById('export-img').addEventListener('click', () => {
+  html2canvas(canvas).then(c => {
+    const a = document.createElement('a');
+    a.download = 'design.png';
+    a.href = c.toDataURL();
+    a.click();
+  });
+});

--- a/index.html
+++ b/index.html
@@ -3,70 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-  <!-- Fonts -->
-  <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Heebo:wght@400;600;800&display=swap" rel="stylesheet" />
-
-  <!-- CSS -->
-  <link rel="preload" href="./assets/css/styles.css" as="style" />
-  <link rel="stylesheet" href="./assets/css/styles.css" />
-
-  <title>Layers of Love</title>
+  <title>Design Playground</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎨</text></svg>">
+  <link rel="stylesheet" href="./assets/css/playground.css" />
 </head>
 <body>
-  <div id="bg"></div>
+  <header class="top-bar"><h1>Design Playground</h1></header>
+  <div class="playground">
+    <aside id="palette" aria-label="Component palette"></aside>
+    <main id="canvas" tabindex="0" aria-label="Design canvas"></main>
+  </div>
+  <div class="actions">
+    <button id="export-html">Export HTML</button>
+    <button id="export-img">Export Screenshot</button>
+  </div>
+  <textarea id="output" aria-label="Export output"></textarea>
 
-  <header class="site-header" role="banner">
-    <!-- Left: language toggle -->
-    <div class="lang-toggle">
-      <input id="langSwitch" class="switch" type="checkbox" aria-label="Toggle language" />
-    </div>
-
-    <!-- Center: cursive brand title -->
-    <h1 class="brand-title" data-i18n="brand">Layers of Love</h1>
-
-    <!-- Right: hamburger -->
-    <button id="hamburger" class="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mainMenu">
-      <span class="bars" aria-hidden="true"></span>
-    </button>
-
-    <!-- Dropdown menu -->
-    <nav id="mainMenu" class="menu" aria-label="Primary">
-      <ul>
-        <li><a href="./index.html" data-i18n="nav.today">Today</a></li>
-        <li><a href="./podcasts.html" data-i18n="nav.podcasts">Podcasts</a></li>
-        <li><a href="./social.html" data-i18n="nav.social">Social Media</a></li>
-        <li><a href="./inspiration.html" data-i18n="nav.daily">Daily Inspiration</a></li>
-        <li><a href="./about.html" data-i18n="nav.about">About</a></li>
-      </ul>
-    </nav>
-  </header>
-
-  <main>
-    <section class="hero">
-      <p class="hero-line" data-i18n="heroLine">make something gentle today.</p>
-      <div class="cta">
-        <a class="btn primary" href="#" aria-disabled="true" data-i18n="cta.ritual">Start 2-minute ritual</a>
-        <a class="btn ghost" href="#" aria-disabled="true" data-i18n="cta.prompts">Explore prompts</a>
-      </div>
-    </section>
-
-    <section class="pillars">
-      <div class="pill">
-        <h3 data-i18n="pill1.title">Daily Prompts</h3>
-        <p data-i18n="pill1.body">Soft, mindful invitations for writing, sketching, or voice notes.</p>
-      </div>
-      <div class="pill">
-        <h3 data-i18n="pill2.title">Gentle Rituals</h3>
-        <p data-i18n="pill2.body">Two-minute breath and reflect moments to return to center.</p>
-      </div>
-      <div class="pill">
-        <h3 data-i18n="pill3.title">Your Gallery</h3>
-        <p data-i18n="pill3.body">Private by default—your quiet wins, saved with care.</p>
-      </div>
-    </section>
-  </main>
-
-  <script type="module" src="./assets/js/app.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script src="./assets/js/playground.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace index with a "Design Playground" for arranging UI ideas
- add palette and canvas with drag-and-drop support
- include HTML export and screenshot capture helpers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb064a3890832386ec9763f36d332c